### PR TITLE
Allowing spaces in the guild config menu after ':'

### DIFF
--- a/guild_info.lua
+++ b/guild_info.lua
@@ -12,7 +12,7 @@ local AE = LibStub("AceEvent-3.0")
 -- @OUTSIDERS:[0 or 1]
 local global_config_defs = {
   decay_p = {
-    pattern = "@DECAY_P:(%d+)",
+    pattern = "@DECAY_P:%s*(%d+)",
     parser = tonumber,
     validator = function(v) return v >= 0 and v <= 100 end,
     error = L["Decay Percent should be a number between 0 and 100"],
@@ -21,7 +21,7 @@ local global_config_defs = {
     change_message = "DecayPercentChanged",
   },
   extras_p = {
-    pattern = "@EXTRAS_P:(%d+)",
+    pattern = "@EXTRAS_P:%s*(%d+)",
     parser = tonumber,
     validator = function(v) return v >= 0 and v <= 100 end,
     error = L["Extras Percent should be a number between 0 and 100"],
@@ -30,7 +30,7 @@ local global_config_defs = {
     change_message = "ExtrasPercentChanged",
   },
   min_ep = {
-    pattern = "@MIN_EP:(%d+)",
+    pattern = "@MIN_EP:%s*(%d+)",
     parser = tonumber,
     validator = function(v) return v >= 0 end,
     error = L["Min EP should be a positive number (>= 0)"],
@@ -39,7 +39,7 @@ local global_config_defs = {
     change_message = "MinEPChanged",
   },
   base_gp = {
-    pattern = "@BASE_GP:(%d+)",
+    pattern = "@BASE_GP:%s*(%d+)",
     parser = tonumber,
     validator = function(v) return v >= 0 end,
     error = L["Base GP should be a positive number (>= 0)"],
@@ -48,7 +48,7 @@ local global_config_defs = {
     change_message = "BaseGPChanged",
   },
   outsiders = {
-    pattern = "@OUTSIDERS:(%d+)",
+    pattern = "@OUTSIDERS:%s*(%d+)",
     parser = tonumber,
     validator = function(v) return v == 0 or v == 1  end,
     error = L["Outsiders should be 0 or 1"],


### PR DESCRIPTION
I was configuring stuff and couldn't figure out why it didn't work -- this was why...